### PR TITLE
Lower bylaws approval threshold from 3 to 2

### DIFF
--- a/.github/workflows/bylaws-approval.yml
+++ b/.github/workflows/bylaws-approval.yml
@@ -28,7 +28,7 @@ jobs:
             const bylawsChanged = files.some(f => f.filename === 'BYLAWS.md');
             core.setOutput('bylaws', bylawsChanged.toString());
 
-      - name: Require 3 approvals for BYLAWS.md changes
+      - name: Require 2 approvals for BYLAWS.md changes
         if: steps.changed.outputs.bylaws == 'true'
         uses: actions/github-script@v7
         with:
@@ -53,9 +53,9 @@ jobs:
               state => state === 'APPROVED'
             ).length;
 
-            if (approvals < 3) {
+            if (approvals < 2) {
               core.setFailed(
-                `BYLAWS.md changes require at least 3 approvals (currently ${approvals}).`
+                `BYLAWS.md changes require at least 2 approvals (currently ${approvals}).`
               );
             } else {
               core.info(`BYLAWS.md change approved with ${approvals} approval(s).`);

--- a/.github/workflows/label-amendment.yml
+++ b/.github/workflows/label-amendment.yml
@@ -1,0 +1,23 @@
+name: Label Amendment PRs
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-label:
+    if: startsWith(github.head_ref, 'amendment/')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add amendment label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['amendment']
+            });


### PR DESCRIPTION
## Summary
- Reduce required PR approvals for BYLAWS.md changes from 3 to 2 in the CI workflow
- The PR author cannot approve their own PR on GitHub, making 3 approvals impractical for a small board

## Test plan
- [ ] Verify the CI workflow file change is correct
- [ ] Confirm the check passes with 2 approvals on a future bylaws PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)