### PR TITLE
Fix tag version comparison to support draft suffixes

### DIFF
--- a/.github/workflows/enforce-names.yml
+++ b/.github/workflows/enforce-names.yml
@@ -59,12 +59,9 @@ jobs:
           fi
           echo "BYLAWS.md version: $BYLAWS_VERSION"
 
-          # Strip -draft-N suffix for version comparison
-          BASE_TAG=$(echo "$TAG_NAME" | sed 's/-draft-[0-9]*//')
-
-          # Compare with tag
+          # Compare tag with BYLAWS.md version
           EXPECTED_TAG="v$BYLAWS_VERSION"
-          if [[ "$BASE_TAG" != "$EXPECTED_TAG" ]]; then
+          if [[ "$TAG_NAME" != "$EXPECTED_TAG" ]]; then
             echo "❌ Tag $TAG_NAME does not match BYLAWS.md version $BYLAWS_VERSION"
             exit 1
           else


### PR DESCRIPTION
## Summary
- Stop stripping `-draft-N` from tag names in `enforce-names.yml` before comparing with the `Version:` field in `BYLAWS.md`
- Draft tags like `v1.0-draft-1` should match `Version: 1.0-draft-1` directly, rather than stripping to `v1.0` and expecting `Version: 1.0`
- Verified that `scripts/merge.sh` already preserves the `-draft-N` suffix correctly

## Test plan
- [ ] Push a draft tag (e.g. `v1.0-draft-1`) with `Version: 1.0-draft-1` in BYLAWS.md and confirm CI passes
- [ ] Push a non-draft tag (e.g. `v1.1`) with `Version: 1.1` in BYLAWS.md and confirm CI still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)