### PR TITLE
Fix deploy workflow: version extraction and WordPress API query

### DIFF
--- a/.github/workflows/deploy-bylaws.yml
+++ b/.github/workflows/deploy-bylaws.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Extract version from BYLAWS.md
         id: version
         run: |
-          version=$(grep -m1 '^Version:' BYLAWS.md | sed 's/Version:[[:space:]]*//')
+          version=$(grep -m1 '^\*\*Version:\*\*' BYLAWS.md | sed 's/\*\*Version:\*\*[[:space:]]*//')
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Deploy to WordPress
@@ -37,10 +37,10 @@ jobs:
         run: |
           HTML_CONTENT=$(cat bylaws.html)
 
-          # Check if a page with slug "bylaws" already exists
+          # Check if a published page with slug "bylaws" already exists
           EXISTING=$(curl -s \
             -u "$WP_APP_USERNAME:$WP_APP_PASSWORD" \
-            "$WP_REST_URL/wp/v2/pages?slug=bylaws&status=publish,draft")
+            "$WP_REST_URL/wp/v2/pages?slug=bylaws")
 
           PAGE_ID=$(echo "$EXISTING" | jq -r '.[0].id // empty')
 

--- a/.github/workflows/deploy-bylaws.yml
+++ b/.github/workflows/deploy-bylaws.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Deploy to WordPress
         env:
-          WP_REST_URL: ${{ secrets.WP_REST_URL }}
+          WP_REST_URL: ${{ vars.WP_REST_URL }}
           WP_APP_USERNAME: ${{ secrets.WP_APP_USERNAME }}
           WP_APP_PASSWORD: ${{ secrets.WP_APP_PASSWORD }}
         run: |


### PR DESCRIPTION
## Summary

- **Version extraction**: regex `^Version:` didn't match the bold Markdown header `**Version:** 1.0-draft-1`, leaving `version` empty — the release step would have created a tag named `v` rather than `v1.0-draft-1`
- **WordPress API**: querying `status=publish,draft` requires the API user to have permission to read drafts; without it the API returns an error object instead of an array, breaking `jq '.[0].id'` with exit code 5. Removed the status filter — the default returns published pages only, which is all we need for the create-or-update check.

## Test plan

- [ ] Merge and retrigger the deploy (delete/recreate `v1.0-draft-1` tag)
- [ ] Confirm version is correctly extracted as `1.0-draft-1`
- [ ] Confirm WordPress deploy step succeeds
- [ ] Confirm GitHub release is created as `v1.0-draft-1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)