### PR TITLE
Fix deploy: skip Puppeteer Chromium download, use system Chrome, cache npm

### DIFF
--- a/.github/workflows/deploy-bylaws.yml
+++ b/.github/workflows/deploy-bylaws.yml
@@ -73,14 +73,19 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
+          cache: 'npm'
 
       - name: Install npm dependencies
         run: npm ci
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: 'true'
 
       - name: Build standalone HTML and PDF
         run: |
           npm run build:html:standalone
           npm run build:pdf
+        env:
+          PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome-stable
 
       - name: Create GitHub release with PDF and standalone HTML
         env:

--- a/.github/workflows/deploy-bylaws.yml
+++ b/.github/workflows/deploy-bylaws.yml
@@ -21,7 +21,7 @@ jobs:
         uses: pandoc/actions/setup@v1
 
       - name: Convert Markdown to HTML fragment
-        run: pandoc BYLAWS.md -f markdown -t html5 -o bylaws.html
+        run: pandoc BYLAWS.md --wrap=none -f markdown -t html5 -o bylaws.html
 
       - name: Extract version from BYLAWS.md
         id: version

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint:md": "markdownlint-cli2 \"**/*.md\" \"#**/node_modules\" \"#.yarn\"",
     "lint:md:fix": "markdownlint-cli2 --fix \"**/*.md\" \"#**/node_modules\" \"#.yarn\"",
     "format:md": "prettier --write \"**/*.md\" \"!**/node_modules/**\"",
-    "build:html": "mkdir -p dist && pandoc BYLAWS.md -f markdown -t html5 -o dist/bylaws.html",
+    "build:html": "mkdir -p dist && pandoc BYLAWS.md --wrap=none -f markdown -t html5 -o dist/bylaws.html",
     "build:html:standalone": "mkdir -p dist && pandoc BYLAWS.md --standalone --embed-resources --css scripts/bylaws-print.css -f markdown -t html5 -o dist/bylaws-standalone.html",
     "build:pdf": "pagedjs-cli --browserArgs='--no-sandbox' dist/bylaws-standalone.html -o dist/bylaws.pdf",
     "tag": "bash scripts/tag.sh",


### PR DESCRIPTION
## Summary

- `pagedjs-cli` triggers a full Chromium download (~300MB) during `npm ci`, causing the install step to hang for 20+ minutes on CI
- Set `PUPPETEER_SKIP_DOWNLOAD=true` during `npm ci` to skip the download
- Set `PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable` when running the build so `pagedjs-cli` uses the system Chrome pre-installed on `ubuntu-latest` runners
- Added `cache: 'npm'` to `actions/setup-node` to speed up subsequent runs

## Test plan

- [ ] Merge and retrigger `v1.0-draft-1` tag
- [ ] Confirm `npm ci` completes in seconds rather than hanging
- [ ] Confirm `build:pdf` succeeds using system Chrome
- [ ] Confirm GitHub release is created with PDF and standalone HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)