### PR TITLE
Add hard line breaks after Version and Original Adoption Date in header

### DIFF
--- a/BYLAWS.md
+++ b/BYLAWS.md
@@ -1,6 +1,6 @@
 # **Bylaws of the Catholic Digital Commons Foundation**
 
-**Version:** 1.0-draft-1
+**Version:** 1.0-draft-1  
 **Original Adoption Date:** 2026-02-25  
 **Last Amended:** 2026-03-11
 


### PR DESCRIPTION
## Summary

- Adds two trailing spaces (Markdown hard line break) after `**Version:**` and `**Original Adoption Date:**` in the bylaws header
- Ensures each metadata field renders on its own line in the HTML output deployed to WordPress
- No change to legal text content

## Test plan

- [ ] Confirm pandoc renders each field on its own line with `<br />` separators
- [ ] Confirm WordPress displays the header fields on separate lines after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)