### PR TITLE
Trim trailing whitespace from extracted version string

### DIFF
--- a/.github/workflows/deploy-bylaws.yml
+++ b/.github/workflows/deploy-bylaws.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Extract version from BYLAWS.md
         id: version
         run: |
-          version=$(grep -m1 '^\*\*Version:\*\*' BYLAWS.md | sed 's/\*\*Version:\*\*[[:space:]]*//')
+          version=$(grep -m1 '^\*\*Version:\*\*' BYLAWS.md | sed 's/\*\*Version:\*\*[[:space:]]*//' | sed 's/[[:space:]]*$//')
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Deploy to WordPress


### PR DESCRIPTION
## Summary

The `**Version:**` line in `BYLAWS.md` ends with two trailing spaces (Markdown hard line break), causing the extracted version to be `1.0-draft-1  ` with trailing spaces — making `gh release create "v1.0-draft-1  "` fail with *"tag_name is not a valid tag"*.

Added a second `sed` pass to strip trailing whitespace from the extracted value.

## Test plan

- [ ] Merge and retrigger `v1.0-draft-1` tag
- [ ] Confirm release is created as `v1.0-draft-1` without trailing spaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)