### PR TITLE
Upgrade GitHub Actions to v6 (Node 24)

### DIFF
--- a/.github/workflows/deploy-bylaws.yml
+++ b/.github/workflows/deploy-bylaws.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install pandoc
-        uses: pandoc/actions/setup@v1
+        uses: pandoc/actions/setup@v1.1.1
 
       - name: Convert Markdown to HTML fragment
         run: pandoc BYLAWS.md --wrap=none -f markdown -t html5 -o bylaws.html
@@ -70,7 +70,7 @@ jobs:
           echo "Deployed bylaws v${{ steps.version.outputs.version }} to WordPress."
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/enforce-names.yml
+++ b/.github/workflows/enforce-names.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Enforce branch naming
         if: startsWith(github.ref, 'refs/heads/')

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 


### PR DESCRIPTION
## Summary

- Upgrade `actions/checkout` from v3/v4 to v6 (Node 24 native)
- Upgrade `actions/setup-node` from v3/v4 to v6 (Node 24 native)
- Upgrade `pandoc/actions/setup` from v1 to v1.1.1

Eliminates the Node 20 deprecation warning in CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)